### PR TITLE
📝 Remove code modification prohibition policy from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,6 @@ This file defines instructions for coding agents working on this project.
 
 ## Project Overview
 
-This project's basic policy is to output documents as requirements definition files, rather than directly modifying or implementing code.
-
 ## Output Directory Rules
 
 ### Output Directory Decision Criteria
@@ -30,8 +28,6 @@ This project's basic policy is to output documents as requirements definition fi
 
 ### Code Modification and Implementation Rules
 
-- **Direct code modification and implementation is prohibited**
-- Do not directly modify code files; instead, append them as implementation files
 - Implementation files must be output to the `outputs/` directory (Markdown format)
 - Information about project specifications (implemented content and requirements) must be output to the `docs/` directory
 - When instructed by the user to output implementation or modification code to implementation files, always include the following information:
@@ -74,7 +70,6 @@ This project's basic policy is to output documents as requirements definition fi
 
 - **`docs/` directory**: Place information about project specifications (implemented content and requirements)
 - **`outputs/` directory**: Place all information other than project specifications (Markdown format, not included in git history)
-- Code files: Do not modify directly; describe as requirements definitions
 
 ## Maintenance Policy
 


### PR DESCRIPTION
## Overview

Remove outdated policy statements that prohibited direct code modification and implementation from AGENTS.md.

## Purpose

This change allows agents to modify code files directly when appropriate, aligning with standard development practices. The previous policy was overly restrictive and prevented agents from making necessary code changes.

## Implementation Summary

- Remove "output documents as requirements definition files" policy statement
- Remove "Direct code modification and implementation is prohibited" rule
- Remove "Do not directly modify code files" restriction

## Changes Result

- AGENTS.md: Removed 5 lines containing code modification prohibition policies
- Agents can now modify code files directly when needed

## Areas for Review

- Is the removal of these restrictions appropriate?
- Are there any other policy statements that should be updated?

## Related

- Commit: 6fa6ed5

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/daisukekarasawa/docksphinx/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified policy documentation by removing redundant guidance statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->